### PR TITLE
Update sotu.md

### DIFF
--- a/sotu.md
+++ b/sotu.md
@@ -191,6 +191,7 @@ of the Haskell runtime.
 * [`scotty`](https://hackage.haskell.org/package/scotty) - A beginner-friendly server framework analogous to Ruby's Sinatra
 * [`spock`](https://www.spock.li/) - Lighter than the "enterprise" frameworks, but more featureful than scotty (type-safe routing, sessions, conn pooling, csrf protection, authentication, etc)
 * [`yesod`](https://hackage.haskell.org/package/yesod) / [`yesod-*`](https://hackage.haskell.org/packages/search?terms=yesod) / [`snap`](https://hackage.haskell.org/package/snap) / [`snap-*`](https://hackage.haskell.org/packages/search?terms=snap) / [`happstack-server`](https://hackage.haskell.org/package/happstack-server) / [`happstack-*`](https://hackage.haskell.org/packages/search?terms=happstack) - "Enterprise" server frameworks with all the bells and whistles
+* [`MFlow`](http://hackage.haskell.org/package/MFlow) - Continuation passing framework where the web components are first class
 * [`servant`](https://hackage.haskell.org/package/servant) / [`servant-*`](https://hackage.haskell.org/packages/search?terms=servant) - This server framework might blow your mind
 * [`authenticate`](https://hackage.haskell.org/package/authenticate) / [`authenticate-*`](https://hackage.haskell.org/packages/search?terms=authenticate) - Shared authentication libraries
 * [`ekg`](https://hackage.haskell.org/package/ekg) / [`ekg-*`](https://hackage.haskell.org/packages/search?terms=ekg) - Haskell service monitoring
@@ -383,6 +384,7 @@ communities of their own.
 **Notable libraries:**
 
 * [reflex-dom](https://hackage.haskell.org/package/reflex-dom) - Functional reactive programming library for DOM manipulation
+* [hplayground](github.com/agocorona/hplayground) Functional reactive EDSL with widget combinators for the Haste compiler 
 
 <br>
 


### PR DESCRIPTION
I added MFlow and hplayground to the mentions.

MFlow is the only web framework that uses haskell abstractions such is monad, applicatives, alternatives to create navigations and single page applications that are composable. The only web framework where navigations can compose and where formlets exhibit dynamic behaviours among other unique features. I think that this package  is worth to mention.

hplayground is the same EDSL for page composition used in MFlow , but compiled with the Haste compiler and running client side instead of in the server.. hplaygroud is the only client side framework where widgets are composable with monadic, applicative and alternative combinators. There is no mention of FRP frameworks for Haste and hplayground is the most developed, with demos, tutorials, an a basic IDE
