### PR TITLE
Edit section Single Machine Concurrency

### DIFF
--- a/sotu.md
+++ b/sotu.md
@@ -821,6 +821,7 @@ Notable libraries:
 * [`stm`](https://hackage.haskell.org/package/stm) - Software transactional memory
 * [`unagi-chan`](https://hackage.haskell.org/package/unagi-chan) - High performance channels
 * [`async`](https://hackage.haskell.org/package/async) - Futures library
+* [`parallel-io`](https://hackage.haskell.org/package/parallel-io) - An easy-to-use task-parallel library, most noted by the type signature `parallel :: [IO a] -> IO [a]`
 
 Educational resources:
 


### PR DESCRIPTION
Add parallel-io to the list of the Single Machine Concurrency libraries.
