### PR TITLE
Replace https with http for Monadic Parsing link

### DIFF
--- a/sotu.md
+++ b/sotu.md
@@ -1146,7 +1146,7 @@ love writing pretty-printing libraries in Haskell for some reason.
 
 **Educational resources:**
 
-* [Monadic Parsing in Haskell](https://www.cs.nott.ac.uk/~gmh/pearl.pdf)
+* [Monadic Parsing in Haskell](http://www.cs.nott.ac.uk/~gmh/pearl.pdf)
 
 **Propaganda:**
 


### PR DESCRIPTION
Monadic Parsing in Haskell paper is not available at https link. If http
is used, link resolves and redirects correctly to the PDF of the paper.
