### PR TITLE
Link to correct Hackage package for Haste

### DIFF
--- a/sotu.md
+++ b/sotu.md
@@ -387,7 +387,7 @@ communities of their own.
 **Notable Haskell-to-Javascript compilers:**
 
 * [`ghcjs`](https://github.com/ghcjs/ghcjs)
-* [`haste`](https://hackage.haskell.org/package/haste)
+* [`haste`](https://hackage.haskell.org/package/haste-compiler)
 
 **Notable libraries:**
 


### PR DESCRIPTION
The package is `haste-compiler`, not `haste`.
