### PR TITLE
Add purity as an advantage of Haskell

### DIFF
--- a/sotu.md
+++ b/sotu.md
@@ -820,6 +820,7 @@ Most statically typed languages are easy to maintain, but Haskell is on its
 own level for the following reasons:
 
 * Strong types
+* Purity
 * Global type inference
 * Type classes
 * Laziness


### PR DESCRIPTION
Having had the dubious honor of maintaining 3 million lines of C++, I can say it was the endless side-effects that killed us!  We couldn't change anything without considering tons of code.  What we would have given for pure functions!

Strong-typing in an imperative language is a sham, because functions with signatures like "int foo(int x)" can do whatever they like.