### PR TITLE
Add IDE support chart

### DIFF
--- a/sotu.md
+++ b/sotu.md
@@ -1647,6 +1647,24 @@ Also, if you have a Mac then the "Haskel for Mac" development environment is
 supposed to work really well for learning since it provides an interactive and
 visual playground for exploring the code.
 
+**Support chart (with links to plug-ins)**
+
+| IDE | Syntax highlight | Code Completion | Lint | Code Format | Goto Def | Find Usages | Debugger | Doc. tooltips | Snippets | Hoogle |
+|:---:|:----------------:|:---------------:|:----:|:-----------:|:--------:|:-----------:|:--------:|:-------------:|:--------:|:------:|
+| Atom     | [🌑](https://atom.io/packages/language-haskell "language-haskell") | [🌓](https://atom.io/packages/autocomplete-haskell "ghc-mod via autocomplete-haskell") | 🌓 | [🌕](https://github.com/chrisdone/hindent "hindent") | 🌓 | … | [🌓](https://atom.io/packages/haskell-debug "haskell-debug") | … | … | [🌓](https://atom.io/packages/haskell-hoogle "haskell-hoogle") |
+| Emacs    | [🌑](http://haskell.github.io/haskell-mode/ "haskell-mode") | 🌓 | 🌓 | [🌓](https://github.com/chrisdone/hindent "hindent") | … | … | … | … | … | … |
+| Intellij | 🌑 | … | … | … | … | … | … | … | … | … |
+| Vim      | 🌑 | 🌕 | [🌓](https://github.com/vim-syntastic/syntastic "syntastic") | [🌓](https://github.com/chrisdone/hindent "hindent") | 🌕 | … | … | [🌓](https://github.com/bitc/vim-hdevtools "vim-hdevtools") | … | … |
+| VSCode   | [🌑](https://marketplace.visualstudio.com/items?itemName=justusadam.language-haskell "Haskell Syntax Highlighting") | … | [🌓](https://marketplace.visualstudio.com/items?itemName=hoovercj.haskell-linter "haskell-linter") | [🌓](https://marketplace.visualstudio.com/items?itemName=monofon.hindent-format "hindent") | [🌓](https://marketplace.visualstudio.com/items?itemName=UCL.haskelly "Haskelly") | … | [🌕](https://marketplace.visualstudio.com/items?itemName=phoityne.phoityne-vscode "Phoityne") | [🌓](https://marketplace.visualstudio.com/items?itemName=UCL.haskelly "Haskelly") | … | … |
+
+
+| Symbol | Support Level                         |
+|:------:|:------------------------------------- |
+| …      | Unknown, support is uncertain         |
+| 🌕     | Immature, only for early-adopters     |
+| 🌓     | Mature, suitable for most programmers |
+| 🌑     | The best™ experience                  |
+
 **Notable tools:**
 
 * [`hoogle`](https://www.haskell.org/hoogle/) — Type-based function search


### PR DESCRIPTION
Hello,

I figured out that editor/IDE features could be tracked using a chart.

In this pr there is a basic example, inspired by [rust areweideyet](https://areweideyet.com/).

Thanks in advance!