### PR TITLE
Add ansi-terminal

### DIFF
--- a/sotu.md
+++ b/sotu.md
@@ -309,6 +309,7 @@ features such as:
 * [`haskeline`](https://hackage.haskell.org/package/haskeline) - a complete Haskell implementation of `readline` for console
   building
 * [`process`](https://hackage.haskell.org/package/process) - low-level library for sub-process management
+* [`ansi-terminal`](https://hackage.haskell.org/package/ansi-terminal) - de facto standard cross-platform terminal library (works on Windows as well)
 
 **Some command-line tools written in Haskell:**
 


### PR DESCRIPTION
It's essential for cross-platform command line tools (e.g. it's used by stack, hlint and so on)