### PR TITLE
Add `massiv` to Numerics section

### DIFF
--- a/sotu.md
+++ b/sotu.md
@@ -449,7 +449,7 @@ upward.
 
 * [`accelerate`](https://hackage.haskell.org/package/accelerate) / [`accelerate-*`](https://hackage.haskell.org/packages/search?terms=accelerate) - GPU programming
 * [`vector`](https://hackage.haskell.org/package/vector) - high-performance arrays
-* [`repa`](https://hackage.haskell.org/package/repa) / [`repa-*`](https://hackage.haskell.org/packages/search?terms=repa) - parallel shape-polymorphic arrays
+* [`massiv`](https://hackage.haskell.org/package/massiv) / [`repa`](https://hackage.haskell.org/package/repa) / [`repa-*`](https://hackage.haskell.org/packages/search?terms=repa) - parallel shape-polymorphic arrays
 * [`hmatrix`](https://hackage.haskell.org/package/hmatrix) / [`hmatrix-*`](https://hackage.haskell.org/packages/search?terms=hmatrix) - Haskell's BLAS / LAPACK wrapper
 * [`ad`](https://hackage.haskell.org/package/ad) - automatic differentiation
 


### PR DESCRIPTION
It provides a more robust API and has better performance than `repa`.