### PR TITLE
There's currently only one code formatting tool

### DIFF
--- a/sotu.md
+++ b/sotu.md
@@ -1469,7 +1469,7 @@ Haskell has decent logging support.  That's pretty much all there is to say.
 
 **Rating:** Mature
 
-Haskell provides two tools for automatic code formatting:
+Haskell has tool(s) for automatic code formatting:
 
 * `stylish-haskell` - Less opinionated code formatting tool that mostly
   formats imports, language extensions, and data type definitions


### PR DESCRIPTION
The other was removed in https://github.com/Gabriel439/post-rfc/commit/df1af7179cf8ed4c5c3bc9950e46f9979a653ae7.