### PR TITLE
Update Education icon to match rating in section

### DIFF
--- a/sotu.md
+++ b/sotu.md
@@ -97,7 +97,7 @@ Legend:
   * 🥈 [Package management](#package-management)
   * 🥈 [Logging](#logging)
   * 🥈 [Code formatting](#code-formatting)
-  * 🌱 [Education](#education)
+  * 🥈 [Education](#education)
   * 🌱 [Databases and data stores](#databases-and-data-stores)
   * 🌱 [Debugging](#debugging)
   * 🌱 [Cross-platform support](#cross-platform-support)


### PR DESCRIPTION
https://github.com/Gabriel439/post-rfc/blob/master/sotu.md#education has the rating as Mature and I updated the icon accordingly.  I'm not able to know which is correct.